### PR TITLE
[WIP] feat: dynamic qps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
 
 [[package]]
+name = "atomic-interval"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b154f952b094dcde3ce05caa7ce81a619ba2f0d6c21d0b19b0be3a74fe0aa9d"
+dependencies = [
+ "quanta",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,7 +556,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -685,6 +694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,7 +734,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
 ]
 
@@ -744,6 +762,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",
+ "atomic-interval",
  "cached",
  "clap 4.0.16",
  "criterion",
@@ -1000,6 +1019,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1515,6 +1559,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rdkafka = { version = "0.24", features = ["cmake-build"] }
 envy = "0.4"
 rand_chacha="0.3.1"
 futures = "0.3"
+atomic-interval = "0.1.3"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio"] }

--- a/src/generator/config.rs
+++ b/src/generator/config.rs
@@ -21,7 +21,7 @@ impl GeneratorConfig {
         first_event_id: u64,
         first_event_number: usize,
     ) -> Self {
-        let inter_event_delay_microseconds = 1_000_000.0 / (nexmark_config.event_rate as f64);
+        let inter_event_delay_microseconds = Self::get_inter_event_delay(&nexmark_config);
         let max_events = match nexmark_config.max_events {
             0 => u64::MAX,
             _ => nexmark_config.max_events,
@@ -34,6 +34,15 @@ impl GeneratorConfig {
             max_events,
             inter_event_delay_microseconds,
         }
+    }
+
+    pub fn get_inter_event_delay(nexmark_config: &NexmarkConfig) -> f64 {
+        1_000_000.0 / (nexmark_config.event_rate as f64)
+    }
+
+    pub fn get_delay_per_generator(nexmark_config: &NexmarkConfig) -> f64 {
+        GeneratorConfig::get_inter_event_delay(nexmark_config)
+            * nexmark_config.num_event_generators as f64
     }
 
     pub fn next_event_number(&self, num_events: u64) -> u64 {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod events;
 pub mod source;
 
+#[derive(Clone)]
 pub struct NexmarkGenerator<R: Rng> {
     config: GeneratorConfig,
     rng: R,
@@ -33,7 +34,7 @@ where
             rng,
             bid_channel_cache: SizedCache::with_size(CHANNELS_NUMBER as usize),
             events_counts_so_far: 0,
-            nexmark_source: nexmark_source,
+            nexmark_source,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,24 @@
 use generator::NexmarkGenerator;
 use generator::{config::GeneratorConfig, source::NexmarkSource};
 use parser::NexmarkConfig;
+use rand::distributions::Uniform;
+use rand::prelude::Distribution;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
-use tokio::time;
+use std::time::SystemTime;
+use tokio::time::{self, Instant};
 pub mod generator;
 pub mod parser;
 pub mod producer;
+use std::sync::atomic::Ordering;
 
 static SEED: u64 = 0;
+
+struct IntervalState {
+    interval: AtomicU64,
+}
 
 /// Creates generators from config options and sends events directly to kafka
 pub async fn create_generators_for_config<'a, T>(
@@ -24,6 +32,9 @@ pub async fn create_generators_for_config<'a, T>(
         .unwrap()
         .as_millis() as u64;
     let mut v = Vec::<tokio::task::JoinHandle<()>>::new();
+    let interval_state = Arc::new(IntervalState {
+        interval: AtomicU64::new(GeneratorConfig::get_delay_per_generator(nexmark_config) as u64),
+    });
     let start_time = SystemTime::now();
     for generator_num in 0..nexmark_config.num_event_generators {
         let generator_config = GeneratorConfig::new(
@@ -33,15 +44,20 @@ pub async fn create_generators_for_config<'a, T>(
             generator_num,
         );
         let source = Arc::clone(nexmark_source);
-        let jh = tokio::spawn(async move {
-            let rng = ChaCha8Rng::seed_from_u64(SEED);
-            let delay = generator_config.inter_event_delay_microseconds;
-            let mut interval = time::interval(Duration::from_micros(
-                delay as u64 * generator_config.nexmark_config.num_event_generators as u64,
-            ));
-            let mut generator = NexmarkGenerator::new(generator_config.clone(), rng, source);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let mut generator = NexmarkGenerator::new(generator_config.clone(), rng.clone(), source);
+        let interval_state = interval_state.clone();
+        let jh = tokio::task::spawn_blocking(move || {
             loop {
-                interval.tick().await;
+                let now = Instant::now();
+                if generator_config.nexmark_config.dynamic_qps
+                    && generator.get_next_event_id() % 10000 == 0
+                {
+                    interval_state.interval.store(
+                        generate_dynamic_period(&generator_config.nexmark_config, &mut rng),
+                        Ordering::Relaxed,
+                    );
+                }
                 let next_event = generator.next_event();
                 match &next_event {
                     Ok(e) => match e {
@@ -57,8 +73,15 @@ pub async fn create_generators_for_config<'a, T>(
                         }
                         None => break,
                     },
-                    Err(err) => eprintln!("Error in generating event {:?}: {}", &next_event, &err),
+                    Err(err) => {
+                        eprintln!("Error in generating event {:?}: {}", &next_event, &err)
+                    }
                 };
+                while (now.elapsed().as_micros() as u64)
+                    < interval_state.interval.load(Ordering::Relaxed)
+                {
+                    std::hint::spin_loop()
+                }
             }
             generator
                 .nexmark_source
@@ -76,4 +99,11 @@ pub async fn create_generators_for_config<'a, T>(
         nexmark_config.max_events,
         SystemTime::elapsed(&start_time).unwrap()
     );
+}
+
+fn generate_dynamic_period<T: Rng>(nexmark_config: &NexmarkConfig, rng: &mut T) -> u64 {
+    let min_event_rate = 1 as u64;
+    let max_event_rate = 2 * GeneratorConfig::get_delay_per_generator(nexmark_config) as u64;
+    let dist = Uniform::from(min_event_rate..max_event_rate);
+    dist.sample(rng)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -51,6 +51,9 @@ pub struct NexmarkConfig {
 
     #[clap(long, short, action)]
     pub create_topic: bool,
+
+    #[clap(long, short, action)]
+    pub dynamic_qps: bool,
 }
 
 impl Default for NexmarkConfig {
@@ -72,6 +75,7 @@ impl Default for NexmarkConfig {
             person_proportion: 1,
             source_buffer_size: 10_000,
             create_topic: false,
+            dynamic_qps: false,
         }
     }
 }


### PR DESCRIPTION
Need to find a better way to implement this. Right now, uses an atomic variable to indicate the amount which different threads should spin, then uses busy waiting and spawn_blocking to keep each thread generating with the desired difference between concurrent events. Seems to work, but overall event generation rate is bottlenecked a fair bit because of this. Investigate why