### PR TITLE
feat: support specify tables to skip

### DIFF
--- a/.github/workflows/pr-unit-test.yml
+++ b/.github/workflows/pr-unit-test.yml
@@ -26,7 +26,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  orchestrator-test:
+  nexmark-server-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
         run: |
           # If new CI checks are added, the one with `--locked` must be run first.
           make rust_clippy_check_locked
-      - name: Build Orchestrator
+      - name: Build Nexmark Server
         run: make rust_build
       - name: Unit Test
         run: make rust_test

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Delivered 400000 events in 1.015285s
 
 You can also set the --max-events flag to 0, to make the number of events generated unlimited.
 
+To skip tables, use flag `--skip-event-types`. For `--skip-event-types="person"`, the server will not generate events for the `person` tables.
+The ratio between bid and auction will keep unchanged and the event rate will be the event rates' sum of `auction` table and `bid` table. `--skip-event-types="person,bid"` means only produce the auction events.
+
 ## Dynamically adjusting event rate
 The event rate set via command line flags can be adjusted by sending an API request to ```http://127.0.0.1:8000/nexmark/qps``` (localhost running on port 8000). This dynamic QPS adjustment enables you to change the event-rate on the fly, and ramps up the production rate of all threads. To keep the QPS scaling as smooth as possible, this is done on a best effort basis for each thread, so the qps adjustment may take some time to reflect. Allow some time for the kafka buffer to be flushed as well, before the change in QPS is reflected. 
 

--- a/src/generator/config.rs
+++ b/src/generator/config.rs
@@ -7,21 +7,35 @@ pub struct GeneratorConfig {
     pub base_time: u64,
     pub max_events: u64,
     pub generator_num: u64,
+    pub skip_person: bool,
+    pub skip_auction: bool,
+    pub skip_bid: bool,
 }
 
 impl GeneratorConfig {
-    pub fn new(max_events: u64, base_time: u64, generator_num: u64) -> Self {
+    pub fn new(
+        max_events: u64,
+        base_time: u64,
+        generator_num: u64,
+        skip_event_types: String,
+    ) -> Self {
         let properties = NexmarkProperties::default();
         let config = NexmarkConfig::from(properties).unwrap();
         let max_events = match max_events {
             0 => u64::MAX,
             _ => max_events,
         };
+        let skip_person = skip_event_types.contains("person");
+        let skip_auction = skip_event_types.contains("auction");
+        let skip_bid = skip_event_types.contains("bid");
         Self {
             nexmark_config: config,
             base_time,
             generator_num,
             max_events,
+            skip_person,
+            skip_auction,
+            skip_bid,
         }
     }
 

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -21,12 +21,23 @@ impl NexmarkGenerator {
     }
 
     pub fn next_event(&mut self) -> Option<Event> {
-        let new_event_id = self.local_events_so_far * self.config.generator_num + self.index;
-        if new_event_id >= self.config.max_events {
-            return None;
+        loop {
+            let new_event_id = self.local_events_so_far * self.config.generator_num + self.index;
+            if new_event_id >= self.config.max_events {
+                return None;
+            }
+            if let Some((event, _)) = Event::new(
+                new_event_id as usize,
+                &self.config.nexmark_config,
+                0,
+                self.config.skip_person,
+                self.config.skip_auction,
+                self.config.skip_bid,
+            ) {
+                self.local_events_so_far += 1;
+                return Some(event);
+            }
+            self.local_events_so_far += 1;
         }
-        let (event, _) = Event::new(new_event_id as usize, &self.config.nexmark_config, 0);
-        self.local_events_so_far += 1;
-        Some(event)
     }
 }

--- a/src/generator/nexmark/event.rs
+++ b/src/generator/nexmark/event.rs
@@ -35,8 +35,36 @@ impl Event {
         events_so_far: usize,
         nex: &NexmarkConfig,
         wall_clock_base_time: usize,
-    ) -> (Event, usize) {
+        skip_person: bool,
+        skip_auction: bool,
+        skip_bid: bool,
+    ) -> Option<(Event, usize)> {
         let rem = nex.next_adjusted_event(events_so_far) % nex.proportion_denominator;
+        if rem < nex.person_proportion {
+            if skip_person {
+                return None;
+            }
+        } else if rem < nex.person_proportion + nex.auction_proportion {
+            if skip_auction {
+                return None;
+            }
+        } else if skip_bid {
+            return None;
+        };
+        Some(Self::inner_new(
+            rem,
+            events_so_far,
+            nex,
+            wall_clock_base_time,
+        ))
+    }
+
+    fn inner_new(
+        rem: usize,
+        events_so_far: usize,
+        nex: &NexmarkConfig,
+        wall_clock_base_time: usize,
+    ) -> (Event, usize) {
         let timestamp = nex.event_timestamp(nex.next_adjusted_event(events_so_far));
         let new_wall_clock_base_time = timestamp - nex.base_time + wall_clock_base_time;
         let id = nex.first_event_id + nex.next_adjusted_event(events_so_far);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub async fn run_generators(
         server_config.max_events,
         wallclock_base_time,
         server_config.num_event_generators as u64,
+        server_config.skip_event_types,
     );
 
     for generator_idx in 0..server_config.num_event_generators {
@@ -94,8 +95,7 @@ pub async fn run_generators(
                         check_idx = ((1_000_000 / (new_interval + 1)) as f64
                             / INTERVAL_CHECK_FREQUENCY)
                             .ceil() as u64;
-                        print_idx = ((1_000_000 / (new_interval + 1)) as f64
-                            / PRINT_FREQUENCY)
+                        print_idx = ((1_000_000 / (new_interval + 1)) as f64 / PRINT_FREQUENCY)
                             .ceil() as u64;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
             .unwrap(),
         false => {
             let config = RocketConfig {
-                address:  IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                 port: conf.listen_port,
                 ..Default::default()
             };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,6 +17,10 @@ pub struct ServerConfig {
     #[clap(long, default_value = "8000")]
     pub listen_port: u16,
 
+    /// The event type to skip, e.g. "auction,person" means only produce bid events.
+    #[clap(long, default_value = "")]
+    pub skip_event_types: String,
+
     #[clap(long, short, action)]
     pub create_topic: bool,
 }
@@ -28,6 +32,7 @@ impl Default for ServerConfig {
             create_topic: false,
             event_rate: 1000,
             num_event_generators: 3,
+            skip_event_types: String::from(""),
             listen_port: 8000,
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

Add support for skip tables. The server will not generate events for the specified tables.
The ratio between `bid`, `auction` and `person` will keep unchanged. 
The event rate will be the remained table's event rates' sum.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
